### PR TITLE
Close button to new header and sidebar overlap fix

### DIFF
--- a/assets/ultravanilla.css
+++ b/assets/ultravanilla.css
@@ -160,7 +160,7 @@ body {
 }
 
 .tools-buttons {
-    z-index: 500;
+    z-index: 110;
     position: absolute;
     bottom: 5px;
     right: 30px;

--- a/assets/ultravanilla.css
+++ b/assets/ultravanilla.css
@@ -75,7 +75,19 @@ body {
 }
 
 .server-description {
+    display: flex;
+    align-items: center;
+}
+
+.server-description p {
     margin: 10px;
+}
+
+.server-description div.close {
+    font-size: 26px;
+    cursor: pointer;
+    padding: 0 25px;
+    height: 100%;
 }
 
 .uv-logo-name {

--- a/src/page-modifier.ts
+++ b/src/page-modifier.ts
@@ -107,6 +107,10 @@ export default async (ctx: Koa.BaseContext): Promise<void> => {
     )
         .addClass("server-description")
         .appendTo(newHeader);
+    
+    $(".server-description div.close").click(function() {
+        $(".server-description").hide();
+    });
 
     newContainer.append(newHeader);
 

--- a/src/page-modifier.ts
+++ b/src/page-modifier.ts
@@ -100,7 +100,10 @@ export default async (ctx: Koa.BaseContext): Promise<void> => {
         .addClass("header-part server-social server-wiki")
         .appendTo(newHeader);
     $(
-        "<p>UltraVanilla is a small-scale LGBT-friendly community Minecraft survival server with minimal enhancements to the core game. 30 player slots is a sweetspot for a server that is not crowded or discouraging production. Community Projects are suggested and discussed on the discord, anyone is free to contribute! The server usually updates fast, and is currently running on Paper 1.19.3. No resets!</p>",
+        "<div>\
+            <p>UltraVanilla is a small-scale LGBT-friendly community Minecraft survival server with minimal enhancements to the core game. 30 player slots is a sweetspot for a server that is not crowded or discouraging production. Community Projects are suggested and discussed on the discord, anyone is free to contribute! The server usually updates fast, and is currently running on Paper 1.19.3. No resets!</p>\
+            <div class='close'>x</div>\
+        </div>",
     )
         .addClass("server-description")
         .appendTo(newHeader);


### PR DESCRIPTION
Header changes:
Added close button as on mobile it's a bit much and isn't intuitive to reload to hide it.

*styling may not be the best, sorry :uwu:*

![image](https://user-images.githubusercontent.com/2465627/211937245-becc987f-0528-4b2d-88d3-6a7e9d14aea6.png)

Sidebar overlap:
For me, hovering over the sidebar to bring it out is behind the tool buttons which is annoying when there's a few users on, this decreases the z-index on the tool buttons div to 110 as the sidebar is 120 so it'll be behind as badly pictured with the help of ms paint below.

![image](https://user-images.githubusercontent.com/2465627/211937840-9259fef1-5e69-4e1e-9199-82dc13f751e5.png)
